### PR TITLE
provide a serial when not available

### DIFF
--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -918,6 +918,11 @@ static uhd::device_addrs_t findUHDSoapyDevice(const uhd::device_addr_t &args_)
         found.erase(SOAPY_UHD_NO_DEEPER);
         result.push_back(kwargsToDict(found));
         result.back()["type"] = "soapy";
+        if (found.count("serial") == 0)
+        {
+            auto serial = std::hash<std::string>()(SoapySDR::KwargsToString(found));
+            result.back()["serial"] = std::to_string(serial);
+        }
     }
     return result;
 }


### PR DESCRIPTION
This is an issue for some versions of uhd

* resolves https://github.com/pothosware/SoapyAudio/issues/15