### PR TITLE
UHDSoapyDevice: Add <cctype> header needed for std::isdigit.

### DIFF
--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -39,6 +39,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <algorithm>
+#include <cctype>
 
 //Report a positive gain step value for UHD's automatic distribution algorithm.
 //This prevents the gain group rounding algorithm from producing zero values.


### PR DESCRIPTION
I needed this to get SoapyUHD compiling with Boost 1.74 on Windows for conda-forge (see https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=225410&view=logs&jobId=5be07ae1-d8ba-5406-47b6-8e3a3a12f825&j=5be07ae1-d8ba-5406-47b6-8e3a3a12f825&t=0bf03e01-0bec-5b85-5316-b1633322e895). Presumably some Boost change caused the <cctype> header to not be pulled in through another include.