### PR TITLE
When installing, consult SoapySDR for installation dir, not system dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ message(STATUS "UHD root directory: ${UHD_ROOT}")
 message(STATUS "UHD include directories: ${UHD_INCLUDE_DIRS}")
 message(STATUS "UHD libraries: ${UHD_LIBRARIES}")
 
+if (NOT SOAPY_ROOT)
+    get_filename_component(SOAPYSDR_ROOT "${SoapySDR_INCLUDE_DIRS}/.." ABSOLUTE)
+endif()
+message(STATUS "SoapySDR root directory: ${SOAPYSDR_ROOT}")
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${SoapySDR_INCLUDE_DIRS})
 include_directories(${UHD_INCLUDE_DIRS})
@@ -165,6 +170,8 @@ target_link_libraries(soapySupport
 install(TARGETS soapySupport
     DESTINATION ${UHD_ROOT}/lib${LIB_SUFFIX}/uhd/modules
 )
+
+set(CMAKE_INSTALL_PREFIX ${SOAPYSDR_ROOT})
 
 ########################################################################
 # rpath setup - http://www.cmake.org/Wiki/CMake_RPATH_handling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ message(STATUS "UHD root directory: ${UHD_ROOT}")
 message(STATUS "UHD include directories: ${UHD_INCLUDE_DIRS}")
 message(STATUS "UHD libraries: ${UHD_LIBRARIES}")
 
-if (NOT SOAPY_ROOT)
+if (NOT SOAPYSDR_ROOT)
     get_filename_component(SOAPYSDR_ROOT "${SoapySDR_INCLUDE_DIRS}/.." ABSOLUTE)
 endif()
 message(STATUS "SoapySDR root directory: ${SOAPYSDR_ROOT}")


### PR DESCRIPTION
This fixes an issue when SoapySDR isn't installed in a "default" system directory (/usr/local) but is instead part of a larger package system (like HomeBrew), and thus, installed in an alternate location.

With this fix, the SoapyUHD plugin file should end up in the proper library directory no matter how or where SoapySDR was installed.