### PR TITLE
Surface UHD 4.10 'mtu' stream argument

### DIFF
--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -219,6 +219,17 @@ public:
             streamArgs.push_back(underflowPolicyArg);
         }
 
+#if UHD_VERSION >= 4100000
+        SoapySDR::ArgInfo mtuArg;
+        mtuArg.key = "mtu";
+        mtuArg.value = "0";
+        mtuArg.name = "Override link MTU";
+        mtuArg.description = "Override the auto-detected link MTU (UHD >= 4.10). 0 = use detected value.";
+        mtuArg.units = "bytes";
+        mtuArg.type = SoapySDR::ArgInfo::INT;
+        streamArgs.push_back(mtuArg);
+#endif
+
         return streamArgs;
     }
 


### PR DESCRIPTION
## Surface UHD 4.10 'mtu' stream argument

### Changed

- Add an `mtu` ArgInfo entry to `SoapyUHDDevice::getStreamArgsInfo()`.

### Why

UHD 4.10 added an `mtu` stream-arg that overrides the link-detected MTU. The arg already passes through transparently via `kwargsToDict()`; this PR makes it discoverable so Pothos / SoapySDR GUIs and `SoapySDRUtil --probe` show the knob.
