### PR TITLE
Fix latent bugs and missing Boost include

### DIFF
--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -20,6 +20,7 @@
 #include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/property_tree.hpp>
 #include <uhd/version.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cctype>
 #include <iostream>
 

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -321,7 +321,7 @@ public:
         case uhd::rx_metadata_t::ERROR_CODE_TIMEOUT: return SOAPY_SDR_TIMEOUT;
         case uhd::rx_metadata_t::ERROR_CODE_BAD_PACKET: return SOAPY_SDR_CORRUPTION;
         case uhd::rx_metadata_t::ERROR_CODE_ALIGNMENT: return SOAPY_SDR_CORRUPTION;
-        case uhd::rx_metadata_t::ERROR_CODE_LATE_COMMAND: return SOAPY_SDR_STREAM_ERROR;
+        case uhd::rx_metadata_t::ERROR_CODE_LATE_COMMAND: return SOAPY_SDR_TIME_ERROR;
         case uhd::rx_metadata_t::ERROR_CODE_BROKEN_CHAIN: return SOAPY_SDR_STREAM_ERROR;
         }
         return ret;

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -508,7 +508,7 @@ public:
             return __doesMBoardFEPropTreeEntryExist(dir, channel, "iq_balance/enable");
         }
 
-        return SoapySDR::Device::hasDCOffsetMode(dir, channel);
+        return SoapySDR::Device::hasIQBalanceMode(dir, channel);
     }
 
     void setIQBalanceMode(const int dir, const size_t channel, const bool automatic)

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -722,7 +722,6 @@ private:
     const size_t _nchan;
     const size_t _elemSize;
     std::vector<void *> _offsetBuffs;
-    bool _doErrorOnNextRecv;
     bool _nextTimeValid;
     uhd::time_spec_t _nextTime;
     const double &_sampRate;

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -35,6 +35,7 @@
 #include <boost/format.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/bind.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/algorithm/string.hpp>
 


### PR DESCRIPTION
## Fix latent bugs and missing Boost include

### Changed

- `hasIQBalanceMode` now falls back to `SoapySDR::Device::hasIQBalanceMode` (previously delegated to `hasDCOffsetMode`).
- `ERROR_CODE_LATE_COMMAND` now maps to `SOAPY_SDR_TIME_ERROR` (previously `SOAPY_SDR_STREAM_ERROR`).
- Drop unused private member `_doErrorOnNextRecv`.
- Add `#include <boost/lexical_cast.hpp>` to `SoapyUHDDevice.cpp` and `UHDSoapyDevice.cpp`.

### Why

The first two are copy-paste bugs in the existing fallback code. `LATE_COMMAND` is a timestamp issue, not a generic stream error. `boost/lexical_cast.hpp` was being pulled transitively from another Boost header; Boost 1.85+ removed that transitive include, breaking the build under newer toolchains.
