### PR TITLE
Build cleanly against UHD 4.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_minimum_required(VERSION 2.8.12...3.10)
 project(SoapyUHD CXX C)
 enable_testing()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -361,6 +361,9 @@ public:
 
         switch (md.event_code)
         {
+#if UHD_VERSION >= 4100000
+        case uhd::async_metadata_t::EVENT_CODE_OK: break;
+#endif
         case uhd::async_metadata_t::EVENT_CODE_BURST_ACK: flags |= SOAPY_SDR_END_BURST; break;
         case uhd::async_metadata_t::EVENT_CODE_UNDERFLOW: return SOAPY_SDR_UNDERFLOW;
         case uhd::async_metadata_t::EVENT_CODE_SEQ_ERROR: return SOAPY_SDR_CORRUPTION;

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -568,12 +568,12 @@ public:
         _device->closeStream(_stream);
     }
 
-    size_t get_num_channels(void) const
+    size_t get_num_channels(void) const override
     {
         return _nchan;
     }
 
-    size_t get_max_num_samps(void) const
+    size_t get_max_num_samps(void) const override
     {
         return _device->getStreamMTU(_stream);
     }
@@ -584,7 +584,7 @@ public:
         uhd::rx_metadata_t &md,
         const double timeout = 0.1,
         const bool one_packet = false
-    )
+    ) override
     {
         size_t total = 0;
         md.reset();
@@ -674,7 +674,7 @@ public:
         return total;
     }
 
-    void issue_stream_cmd(const uhd::stream_cmd_t &stream_cmd)
+    void issue_stream_cmd(const uhd::stream_cmd_t &stream_cmd) override
     {
         int flags = 0;
         if (not stream_cmd.stream_now) flags |= SOAPY_SDR_HAS_TIME;
@@ -758,12 +758,12 @@ public:
         _device->closeStream(_stream);
     }
 
-    size_t get_num_channels(void) const
+    size_t get_num_channels(void) const override
     {
         return _nchan;
     }
 
-    size_t get_max_num_samps(void) const
+    size_t get_max_num_samps(void) const override
     {
         return _device->getStreamMTU(_stream);
     }
@@ -773,7 +773,7 @@ public:
         size_t nsamps_per_buff,
         const uhd::tx_metadata_t &md,
         const double timeout = 0.1
-    )
+    ) override
     {
         //perform activation at the latest/on the first call to send
         if (not _active)
@@ -808,7 +808,7 @@ public:
         return total;
     }
 
-    bool recv_async_msg(uhd::async_metadata_t &md, double timeout = 0.1)
+    bool recv_async_msg(uhd::async_metadata_t &md, double timeout = 0.1) override
     {
         size_t chanMask = 0;
         int flags = 0;


### PR DESCRIPTION
## Build cleanly against UHD 4.10

### Changed

- Bump `CMAKE_CXX_STANDARD` from 14 to 17.
- Handle `EVENT_CODE_OK` in the async-metadata switch.
- Add `override` specifier to virtual stream methods.

### Why

UHD 4.10 public headers (e.g. `uhd::cast::to_str` in `assert_has.ipp`) require C++17 (`std::optional`, `std::is_same_v`). `EVENT_CODE_OK` is new in 4.10 and triggers `-Wswitch`. `override` silences `-Winconsistent-missing-override`.
