### PR TITLE
Modernize CMake (target-scoped, build toggles)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 ########################################################################
 # Dependencies
 ########################################################################
-find_package(SoapySDR "0.6" NO_MODULE REQUIRED)
+find_package(SoapySDR "0.7" NO_MODULE REQUIRED)
 find_package(UHD NO_MODULE)
 
 #try old-style find script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,7 @@ message(STATUS "UHD root directory: ${UHD_ROOT}")
 message(STATUS "UHD include directories: ${UHD_INCLUDE_DIRS}")
 message(STATUS "UHD libraries: ${UHD_LIBRARIES}")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${SoapySDR_INCLUDE_DIRS})
-include_directories(${UHD_INCLUDE_DIRS})
+set(UHD_FEATURE_DEFS "")
 
 message(STATUS "Checking uhd::device::register_device() API...")
 message(STATUS "  Reading ${UHD_INCLUDE_DIRS}/uhd/device.hpp...")
@@ -68,7 +66,7 @@ string(FIND "${device_hpp}" "device_filter_t" has_device_filter)
 if ("${has_device_filter}" STREQUAL "-1")
     message(STATUS "  has original API")
 else()
-    add_definitions(-DUHD_HAS_DEVICE_FILTER)
+    list(APPEND UHD_FEATURE_DEFS UHD_HAS_DEVICE_FILTER)
     message(STATUS "  has filter API")
 endif()
 
@@ -79,7 +77,7 @@ string(FIND "${multi_usrp_hpp}" "set_rx_agc" has_set_rx_agc)
 if ("${has_set_rx_agc}" STREQUAL "-1")
     message(STATUS "  missing set_rx_agc() API")
 else()
-    add_definitions(-DUHD_HAS_SET_RX_AGC)
+    list(APPEND UHD_FEATURE_DEFS UHD_HAS_SET_RX_AGC)
     message(STATUS "  has set_rx_agc() API")
 endif()
 
@@ -90,12 +88,12 @@ string(FIND "${property_tree_hpp}" "set_publisher" has_set_publisher)
 if ("${has_set_publisher}" STREQUAL "-1")
     message(STATUS "  missing set_publisher() API")
 else()
-    add_definitions(-DUHD_HAS_SET_PUBLISHER)
+    list(APPEND UHD_FEATURE_DEFS UHD_HAS_SET_PUBLISHER)
     message(STATUS "  has set_publisher() API")
 endif()
 
 if (EXISTS "${UHD_INCLUDE_DIRS}/uhd/utils/msg.hpp")
-    add_definitions(-DUHD_HAS_MSG_HPP)
+    list(APPEND UHD_FEATURE_DEFS UHD_HAS_MSG_HPP)
     message(STATUS "  use msg.hpp for logging")
 else()
     message(STATUS "  use log.hpp for logging")
@@ -116,14 +114,18 @@ if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost not found -- required for Soapy UHD support")
 endif()
 
-ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
-
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
+list(APPEND UHD_FEATURE_DEFS BOOST_ALL_DYN_LINK)
 
 message(STATUS "Boost include directories: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost library directories: ${Boost_LIBRARY_DIRS}")
 message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
+
+set(SOAPY_UHD_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${SoapySDR_INCLUDE_DIRS}
+    ${UHD_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+)
 
 ########################################################################
 # Build a Soapy module to support UHD devices
@@ -135,11 +137,15 @@ SOAPY_SDR_MODULE_UTIL(
         ${UHD_LIBRARIES}
         ${Boost_LIBRARIES}
 )
+target_include_directories(uhdSupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
+target_compile_definitions(uhdSupport PRIVATE ${UHD_FEATURE_DEFS})
 
 ########################################################################
 # Build a UHD module to support Soapy devices
 ########################################################################
 add_library(soapySupport MODULE UHDSoapyDevice.cpp)
+target_include_directories(soapySupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
+target_compile_definitions(soapySupport PRIVATE ${UHD_FEATURE_DEFS})
 target_link_libraries(soapySupport
     ${UHD_LIBRARIES}
     ${SoapySDR_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,13 @@ enable_testing()
 
 set(CMAKE_CXX_STANDARD 14)
 
+option(BUILD_UHD_SUPPORT   "Build the SoapySDR-side module exposing UHD devices to SoapySDR"   ON)
+option(BUILD_SOAPY_SUPPORT "Build the UHD-side module exposing Soapy devices to UHD"          ON)
+
+if(NOT BUILD_UHD_SUPPORT AND NOT BUILD_SOAPY_SUPPORT)
+    message(FATAL_ERROR "Both BUILD_UHD_SUPPORT and BUILD_SOAPY_SUPPORT are OFF -- nothing to build.")
+endif()
+
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE "Release")
@@ -130,29 +137,33 @@ set(SOAPY_UHD_INCLUDE_DIRS
 ########################################################################
 # Build a Soapy module to support UHD devices
 ########################################################################
-SOAPY_SDR_MODULE_UTIL(
-    TARGET uhdSupport
-    SOURCES SoapyUHDDevice.cpp
-    LIBRARIES
-        ${UHD_LIBRARIES}
-        ${Boost_LIBRARIES}
-)
-target_include_directories(uhdSupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
-target_compile_definitions(uhdSupport PRIVATE ${UHD_FEATURE_DEFS})
+if(BUILD_UHD_SUPPORT)
+    SOAPY_SDR_MODULE_UTIL(
+        TARGET uhdSupport
+        SOURCES SoapyUHDDevice.cpp
+        LIBRARIES
+            ${UHD_LIBRARIES}
+            ${Boost_LIBRARIES}
+    )
+    target_include_directories(uhdSupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
+    target_compile_definitions(uhdSupport PRIVATE ${UHD_FEATURE_DEFS})
+endif()
 
 ########################################################################
 # Build a UHD module to support Soapy devices
 ########################################################################
-add_library(soapySupport MODULE UHDSoapyDevice.cpp)
-target_include_directories(soapySupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
-target_compile_definitions(soapySupport PRIVATE ${UHD_FEATURE_DEFS})
-target_link_libraries(soapySupport
-    ${UHD_LIBRARIES}
-    ${SoapySDR_LIBRARIES}
-    ${Boost_LIBRARIES})
-install(TARGETS soapySupport
-    DESTINATION ${UHD_ROOT}/lib${LIB_SUFFIX}/uhd/modules
-)
+if(BUILD_SOAPY_SUPPORT)
+    add_library(soapySupport MODULE UHDSoapyDevice.cpp)
+    target_include_directories(soapySupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
+    target_compile_definitions(soapySupport PRIVATE ${UHD_FEATURE_DEFS})
+    target_link_libraries(soapySupport
+        ${UHD_LIBRARIES}
+        ${SoapySDR_LIBRARIES}
+        ${Boost_LIBRARIES})
+    install(TARGETS soapySupport
+        DESTINATION ${UHD_ROOT}/lib${LIB_SUFFIX}/uhd/modules
+    )
+endif()
 
 ########################################################################
 # rpath setup - http://www.cmake.org/Wiki/CMake_RPATH_handling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.12...3.10)
+cmake_minimum_required(VERSION 3.10...3.30)
 project(SoapyUHD CXX C)
 enable_testing()
 

--- a/TypeHelpers.hpp
+++ b/TypeHelpers.hpp
@@ -40,11 +40,7 @@ static inline SoapySDR::RangeList metaRangeToRangeList(const uhd::meta_range_t &
     SoapySDR::RangeList out;
     for (size_t i = 0; i < metaRange.size(); i++)
     {
-        #ifdef SOAPY_SDR_API_HAS_RANGE_TYPE_STEP
         out.push_back(SoapySDR::Range(metaRange[i].start(), metaRange[i].stop(), metaRange[i].step()));
-        #else
-        out.push_back(SoapySDR::Range(metaRange[i].start(), metaRange[i].stop()));
-        #endif
     }
     return out;
 }
@@ -54,11 +50,7 @@ static inline uhd::meta_range_t rangeListToMetaRange(const SoapySDR::RangeList &
     uhd::meta_range_t out;
     for (size_t i = 0; i < ranges.size(); i++)
     {
-        #ifdef SOAPY_SDR_API_HAS_RANGE_TYPE_STEP
         out.push_back(uhd::range_t(ranges[i].minimum(), ranges[i].maximum(), ranges[i].step()));
-        #else
-        out.push_back(uhd::range_t(ranges[i].minimum(), ranges[i].maximum()));
-        #endif
     }
     if (out.empty()) out.push_back(uhd::range_t(0.0));
     return out;
@@ -66,11 +58,7 @@ static inline uhd::meta_range_t rangeListToMetaRange(const SoapySDR::RangeList &
 
 static inline SoapySDR::Range metaRangeToRange(const uhd::meta_range_t &metaRange)
 {
-    #ifdef SOAPY_SDR_API_HAS_RANGE_TYPE_STEP
     return SoapySDR::Range(metaRange.start(), metaRange.stop(), metaRange.step());
-    #else
-    return SoapySDR::Range(metaRange.start(), metaRange.stop());
-    #endif
 }
 
 static inline uhd::meta_range_t numberListToMetaRange(const std::vector<double> &nums)
@@ -106,10 +94,8 @@ static inline std::vector<double> metaRangeToNumericList(const uhd::meta_range_t
 
 static inline uhd::meta_range_t rangeToMetaRange(const SoapySDR::Range &range, double step = 0.0)
 {
-    //when range step is supported, use it only if initialized to non-zero
-    #ifdef SOAPY_SDR_API_HAS_RANGE_TYPE_STEP
+    //use range.step() if initialized to non-zero
     if (range.step() != 0.0) step = range.step();
-    #endif
 
     return uhd::meta_range_t(range.minimum(), range.maximum(), step);
 }

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -111,20 +111,12 @@ public:
 
     uhd::meta_range_t get_bw_range(const int dir, const size_t chan)
     {
-        #ifdef SOAPY_SDR_API_HAS_GET_BANDWIDTH_RANGE
         return rangeListToMetaRange(_device->getBandwidthRange(dir, chan));
-        #else
-        return numberListToMetaRange(_device->listBandwidths(dir, chan));
-        #endif
     }
 
     uhd::meta_range_t get_rate_range(const int dir, const size_t chan)
     {
-        #ifdef SOAPY_SDR_API_HAS_GET_SAMPLE_RATE_RANGE
         return rangeListToMetaRange(_device->getSampleRateRange(dir, chan));
-        #else
-        return numberListToMetaRange(_device->listSampleRates(dir, chan));
-        #endif
     }
 
     void set_sample_rate(const int dir, const size_t chan, const double rate)
@@ -454,14 +446,12 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
             .subscribe(boost::bind(&SoapySDR::Device::setIQBalance, _device, dir, chan, _1));
     }
 
-    #ifdef SOAPY_SDR_API_HAS_IQ_BALANCE_MODE
     if (_device->hasIQBalanceMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "iq_balance" / "enable")
             .publish(boost::bind(&SoapySDR::Device::getIQBalanceMode, _device, dir, chan))
             .subscribe(boost::bind(&SoapySDR::Device::setIQBalanceMode, _device, dir, chan, _1));
     }
-    #endif
 }
 
 void UHDSoapyDevice::setupFakeChannelHooks(const int dir, const size_t /*chan*/, const std::string &dirName, const std::string &chName)


### PR DESCRIPTION
## Modernize CMake (target-scoped, build toggles)

### Changed

- Bump `cmake_minimum_required` from `2.8.12...3.10` to `3.10...3.30`.
- Bump `find_package(SoapySDR ...)` floor from 0.6 to 0.7; drop the four `SOAPY_SDR_API_HAS_*` `#ifdef` blocks (paths dead since 0.7).
- Replace global `add_definitions` / `include_directories` with `target_compile_definitions` / `target_include_directories`.
- Add `BUILD_UHD_SUPPORT` and `BUILD_SOAPY_SUPPORT` options (both default `ON`).

### Why

`cmake_minimum_required 2.8.12` trips CMake 4 deprecation; the bump removes the need for downstream `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` workarounds. SoapySDR 0.7 shipped 2018 -- the `#ifdef` paths are dead on any current distro. Build toggles let consumers (e.g. Homebrew formulae) drop `soapySupport` -- which installs into `${UHD_ROOT}/lib/uhd/modules` outside the build prefix -- without `--target uhdSupport` workarounds.
