### PR TITLE
Drop UHD <4.0 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 message(STATUS "UHD root directory: ${UHD_ROOT}")
 message(STATUS "UHD include directories: ${UHD_INCLUDE_DIRS}")
 message(STATUS "UHD libraries: ${UHD_LIBRARIES}")
+message(STATUS "UHD version: ${UHD_VERSION}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${SoapySDR_INCLUDE_DIRS})

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -12,11 +12,7 @@
 #include <SoapySDR/Logger.hpp>
 #include <uhd/version.hpp>
 #include <uhd/device.hpp>
-#ifdef UHD_HAS_MSG_HPP
-#include <uhd/utils/msg.hpp>
-#else
 #include <uhd/utils/log_add.hpp>
-#endif
 #include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/property_tree.hpp>
 #include <uhd/version.hpp>
@@ -545,21 +541,17 @@ public:
 
     bool hasGainMode(const int dir, const size_t channel) const
     {
-        #ifdef UHD_HAS_SET_RX_AGC
         if (dir == SOAPY_SDR_TX) return false;
         if (dir == SOAPY_SDR_RX)
         {
             return __doesDBoardFEPropTreeEntryExist(dir, channel, "gain/agc/enable");
         }
-        #endif
         return SoapySDR::Device::hasGainMode(dir, channel);
     }
 
     void setGainMode(const int dir, const size_t channel, const bool automatic)
     {
-        #ifdef UHD_HAS_SET_RX_AGC
         if (dir == SOAPY_SDR_RX) return _dev->set_rx_agc(automatic, channel);
-        #endif
         return SoapySDR::Device::setGainMode(dir, channel, automatic);
     }
 
@@ -1043,11 +1035,7 @@ private:
 
     uhd::property_tree::sptr _get_tree(void) const
     {
-        #if UHD_VERSION >= 4000000
         return _dev->get_tree();
-        #else
-        return _dev->get_device()->get_tree();
-        #endif
     }
 
     uhd::usrp::multi_usrp::sptr _dev;
@@ -1058,20 +1046,6 @@ private:
 /***********************************************************************
  * Register into logger
  **********************************************************************/
-#ifdef UHD_HAS_MSG_HPP
-static void SoapyUHDLogger(uhd::msg::type_t t, const std::string &s)
-{
-    if (s.empty()) return;
-    if (s[s.size()-1] == '\n') return SoapyUHDLogger(t, s.substr(0, s.size()-1));
-    switch (t)
-    {
-    case uhd::msg::status: SoapySDR::log(SOAPY_SDR_INFO, s); break;
-    case uhd::msg::warning: SoapySDR::log(SOAPY_SDR_WARNING, s); break;
-    case uhd::msg::error: SoapySDR::log(SOAPY_SDR_ERROR, s); break;
-    case uhd::msg::fastpath: SoapySDR::log(SOAPY_SDR_SSI, s); break;
-    }
-}
-#else
 static void SoapyUHDLogger(const uhd::log::logging_info &info)
 {
     //build a log message formatted from the information
@@ -1101,7 +1075,6 @@ static void SoapyUHDLogger(const uhd::log::logging_info &info)
     default: break;
     }
 }
-#endif
 
 /***********************************************************************
  * Registration
@@ -1114,11 +1087,7 @@ std::vector<SoapySDR::Kwargs> find_uhd(const SoapySDR::Kwargs &args_)
     args[SOAPY_UHD_NO_DEEPER] = "";
 
     //perform the discovery
-    #ifdef UHD_HAS_DEVICE_FILTER
     const uhd::device_addrs_t addrs = uhd::device::find(kwargsToDict(args), uhd::device::USRP);
-    #else
-    const uhd::device_addrs_t addrs = uhd::device::find(kwargsToDict(args));
-    #endif
 
     //convert addrs to results
     std::vector<SoapySDR::Kwargs> results;
@@ -1151,11 +1120,7 @@ SoapySDR::Device *make_uhd(const SoapySDR::Kwargs &args)
         "Suggestion: install an ABI compatible version of UHD,\n"
         "or rebuild SoapySDR UHD support against this ABI version.\n"
     ) % UHD_VERSION_ABI_STRING % uhd::get_abi_string()));
-    #ifdef UHD_HAS_MSG_HPP
-    uhd::msg::register_handler(&SoapyUHDLogger);
-    #else
     uhd::log::add_logger("SoapyUHDDevice", &SoapyUHDLogger);
-    #endif
     return new SoapyUHDDevice(uhd::usrp::multi_usrp::make(kwargsToDict(args)), args);
 }
 

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -2,11 +2,6 @@
 // Copyright (c) 2018 Deepwave Digital, Inc.
 // SPDX-License-Identifier: GPL-3.0
 
-#ifdef UHD_HAS_SET_PUBLISHER
-#define publish set_publisher
-#define subscribe add_desired_subscriber
-#endif
-
 /***********************************************************************
  * A UHD module that supports Soapy devices within the UHD API.
  **********************************************************************/
@@ -17,11 +12,7 @@
 #include <uhd/version.hpp>
 #include <uhd/device.hpp>
 #include <uhd/convert.hpp>
-#ifdef UHD_HAS_MSG_HPP
-#include <uhd/utils/msg.hpp>
-#else
 #include <uhd/utils/log.hpp>
-#endif
 #include <uhd/types/sensors.hpp>
 #include <uhd/types/ranges.hpp>
 #include <uhd/usrp/mboard_eeprom.hpp>
@@ -181,13 +172,8 @@ private:
     std::map<int, std::map<size_t, double>> _sampleRates;
 
     //stash streamers to implement old-style issue stream cmd and async message
-    #if UHD_VERSION >= 4000000
     std::map<size_t, std::weak_ptr<uhd::rx_streamer> > _rx_streamers;
     std::map<size_t, std::weak_ptr<uhd::tx_streamer> > _tx_streamers;
-    #else
-    std::map<size_t, boost::weak_ptr<uhd::rx_streamer> > _rx_streamers;
-    std::map<size_t, boost::weak_ptr<uhd::tx_streamer> > _tx_streamers;
-    #endif
 };
 
 /***********************************************************************
@@ -224,45 +210,45 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 
     //the frontend mapping
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "rx_subdev_spec")
-        .publish(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_RX))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_RX, _1));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_RX))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_RX, _1));
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "tx_subdev_spec")
-        .publish(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_TX))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_TX, _1));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_TX))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_TX, _1));
 
     //timed command support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "cmd")
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "CMD", _1));
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "CMD", _1));
     _tree->create<double>(mb_path / "tick_rate")
-        .publish(boost::bind(&SoapySDR::Device::getMasterClockRate, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setMasterClockRate, _device, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getMasterClockRate, _device))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setMasterClockRate, _device, _1));
 
     //hardware time support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "now")
-        .publish(boost::bind(&UHDSoapyDevice::get_hardware_time, this, ""))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "", _1));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_hardware_time, this, ""))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "", _1));
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "pps")
-        .publish(boost::bind(&UHDSoapyDevice::get_hardware_time, this, "PPS"))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "PPS", _1));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_hardware_time, this, "PPS"))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "PPS", _1));
 
     //clock and time sources
     _tree->create<std::vector<std::string> >(mb_path / "clock_source"/ "options")
-        .publish(boost::bind(&SoapySDR::Device::listClockSources, _device));
+        .set_publisher(boost::bind(&SoapySDR::Device::listClockSources, _device));
     _tree->create<std::string>(mb_path / "clock_source" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getClockSource, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setClockSource, _device, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getClockSource, _device))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setClockSource, _device, _1));
     _tree->create<std::vector<std::string> >(mb_path / "time_source"/ "options")
-        .publish(boost::bind(&SoapySDR::Device::listTimeSources, _device));
+        .set_publisher(boost::bind(&SoapySDR::Device::listTimeSources, _device));
     _tree->create<std::string>(mb_path / "time_source" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getTimeSource, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setTimeSource, _device, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getTimeSource, _device))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setTimeSource, _device, _1));
 
     //mboard sensors
     _tree->create<int>(mb_path / "sensors"); //ensure this path exists
     for(const std::string &name : _device->listSensors())
     {
         _tree->create<uhd::sensor_value_t>(mb_path / "sensors" / name)
-            .publish(boost::bind(&UHDSoapyDevice::get_mboard_sensor, this, name));
+            .set_publisher(boost::bind(&UHDSoapyDevice::get_mboard_sensor, this, name));
     }
 
     //gpio banks
@@ -280,8 +266,8 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
         for(const std::string &attr : attrs)
         {
             _tree->create<boost::uint32_t>(mb_path / "gpio" / bank / attr)
-                .subscribe(boost::bind(&UHDSoapyDevice::set_gpio_attr, this, bank, attr, _1))
-                .publish(boost::bind(&UHDSoapyDevice::get_gpio_attr, this, bank, attr));
+                .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_gpio_attr, this, bank, attr, _1))
+                .set_publisher(boost::bind(&UHDSoapyDevice::get_gpio_attr, this, bank, attr));
         }
     }
 
@@ -342,10 +328,10 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
 
     //samp rate
     _tree->create<uhd::meta_range_t>(dsp_path / "rate" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_rate_range, this, dir, chan));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_rate_range, this, dir, chan));
     _tree->create<double>(dsp_path / "rate" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getSampleRate, _device, dir, chan))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_sample_rate, this, dir, chan, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getSampleRate, _device, dir, chan))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_sample_rate, this, dir, chan, _1));
 
     //dsp freq (when there is no tunable cordic)
     if (bbCompName.empty())
@@ -357,17 +343,17 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     else
     {
         _tree->create<double>(dsp_path / "freq" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, bbCompName))
-            .subscribe(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, bbCompName, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, bbCompName))
+            .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, bbCompName, _1));
         _tree->create<uhd::meta_range_t>(dsp_path / "freq" / "range")
-            .publish(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, bbCompName));
+            .set_publisher(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, bbCompName));
     }
 
     //old style stream cmd
     if (dir == SOAPY_SDR_RX)
     {
         _tree->create<uhd::stream_cmd_t>(dsp_path / "stream_cmd")
-            .subscribe(boost::bind(&UHDSoapyDevice::old_issue_stream_cmd, this, chan, _1));
+            .add_desired_subscriber(boost::bind(&UHDSoapyDevice::old_issue_stream_cmd, this, chan, _1));
     }
 
     //frontend sensors
@@ -376,7 +362,7 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     {
         //install the sensor
         _tree->create<uhd::sensor_value_t>(rf_fe_path / "sensors" / name)
-            .publish(boost::bind(&UHDSoapyDevice::get_channel_sensor, this, dir, chan, name));
+            .set_publisher(boost::bind(&UHDSoapyDevice::get_channel_sensor, this, dir, chan, name));
     }
 
     //dummy eeprom values
@@ -397,69 +383,69 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     for(const std::string &name : _device->listGains(dir, chan))
     {
         _tree->create<uhd::meta_range_t>(rf_fe_path / "gains" / name / "range")
-            .publish(boost::bind(&UHDSoapyDevice::get_gain_range, this, dir, chan, name));
+            .set_publisher(boost::bind(&UHDSoapyDevice::get_gain_range, this, dir, chan, name));
         _tree->create<double>(rf_fe_path / "gains" / name / "value")
-            .publish(boost::bind(&SoapySDR::Device::getGain, _device, dir, chan, name))
-            .subscribe(boost::bind(&SoapySDR::Device::setGain, _device, dir, chan, name, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getGain, _device, dir, chan, name))
+            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setGain, _device, dir, chan, name, _1));
     }
 
     //agc
     _tree->create<bool>(rf_fe_path / "gain" / "agc" / "enable")
-        .publish(boost::bind(&SoapySDR::Device::getGainMode, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setGainMode, _device, dir, chan, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getGainMode, _device, dir, chan))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setGainMode, _device, dir, chan, _1));
 
     //freq
     _tree->create<double>(rf_fe_path / "freq" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, rfCompName))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, rfCompName, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, rfCompName))
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, rfCompName, _1));
     _tree->create<uhd::meta_range_t>(rf_fe_path / "freq" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, rfCompName));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, rfCompName));
     _tree->create<bool>(rf_fe_path / "use_lo_offset").set(false);
     _tree->create<uhd::device_addr_t>(rf_fe_path / "tune_args")
-        .subscribe(boost::bind(&UHDSoapyDevice::stash_tune_args, this, dir, chan, _1));
+        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::stash_tune_args, this, dir, chan, _1));
 
     //ant
     _tree->create<std::vector<std::string> >(rf_fe_path / "antenna" / "options")
-        .publish(boost::bind(&SoapySDR::Device::listAntennas, _device, dir, chan));
+        .set_publisher(boost::bind(&SoapySDR::Device::listAntennas, _device, dir, chan));
     _tree->create<std::string>(rf_fe_path / "antenna" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getAntenna, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setAntenna, _device, dir, chan, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getAntenna, _device, dir, chan))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setAntenna, _device, dir, chan, _1));
 
     //bw
     _tree->create<double>(rf_fe_path / "bandwidth" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getBandwidth, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setBandwidth, _device, dir, chan, _1));
+        .set_publisher(boost::bind(&SoapySDR::Device::getBandwidth, _device, dir, chan))
+        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setBandwidth, _device, dir, chan, _1));
     _tree->create<uhd::meta_range_t>(rf_fe_path / "bandwidth" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_bw_range, this, dir, chan));
+        .set_publisher(boost::bind(&UHDSoapyDevice::get_bw_range, this, dir, chan));
 
     //corrections
     if (_device->hasDCOffsetMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "dc_offset" / "enable")
-            .publish(boost::bind(&SoapySDR::Device::getDCOffsetMode, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setDCOffsetMode, _device, dir, chan, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getDCOffsetMode, _device, dir, chan))
+            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setDCOffsetMode, _device, dir, chan, _1));
     }
 
     if (_device->hasDCOffset(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "dc_offset" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getDCOffset, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setDCOffset, _device, dir, chan, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getDCOffset, _device, dir, chan))
+            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setDCOffset, _device, dir, chan, _1));
     }
 
     if (_device->hasIQBalance(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "iq_balance" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getIQBalance, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setIQBalance, _device, dir, chan, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getIQBalance, _device, dir, chan))
+            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setIQBalance, _device, dir, chan, _1));
     }
 
     #ifdef SOAPY_SDR_API_HAS_IQ_BALANCE_MODE
     if (_device->hasIQBalanceMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "iq_balance" / "enable")
-            .publish(boost::bind(&SoapySDR::Device::getIQBalanceMode, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setIQBalanceMode, _device, dir, chan, _1));
+            .set_publisher(boost::bind(&SoapySDR::Device::getIQBalanceMode, _device, dir, chan))
+            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setIQBalanceMode, _device, dir, chan, _1));
     }
     #endif
 }
@@ -899,17 +885,6 @@ static void UHDSoapyLogger(const SoapySDR::LogLevel logLevel, const char *messag
     #define component "UHDSoapyDevice"
     switch(logLevel)
     {
-    #ifdef UHD_HAS_MSG_HPP
-    case SOAPY_SDR_FATAL:
-    case SOAPY_SDR_CRITICAL:
-    case SOAPY_SDR_ERROR: UHD_MSG(error) << message << std::endl; break;
-    case SOAPY_SDR_WARNING: UHD_MSG(warning) << message << std::endl; break;
-    case SOAPY_SDR_NOTICE:
-    case SOAPY_SDR_INFO:
-    case SOAPY_SDR_DEBUG:
-    case SOAPY_SDR_TRACE: UHD_MSG(status) << message << std::endl; break;
-    case SOAPY_SDR_SSI: UHD_MSG(fastpath) << message << std::flush; break;
-    #else
     case SOAPY_SDR_FATAL:
     case SOAPY_SDR_CRITICAL:  UHD_LOG_FATAL(component, message); break;
     case SOAPY_SDR_ERROR:     UHD_LOG_FATAL(component, message); break;
@@ -919,7 +894,6 @@ static void UHDSoapyLogger(const SoapySDR::LogLevel logLevel, const char *messag
     case SOAPY_SDR_DEBUG:
     case SOAPY_SDR_TRACE:     UHD_LOG_TRACE(component, message); break;
     case SOAPY_SDR_SSI:       UHD_LOG_FASTPATH(message); break;
-    #endif
     }
 }
 
@@ -961,9 +935,5 @@ static uhd::device_addrs_t findUHDSoapyDevice(const uhd::device_addr_t &args_)
 
 UHD_STATIC_BLOCK(registerUHDSoapyDevice)
 {
-    #ifdef UHD_HAS_DEVICE_FILTER
     uhd::device::register_device(&findUHDSoapyDevice, &makeUHDSoapyDevice, uhd::device::USRP);
-    #else
-    uhd::device::register_device(&findUHDSoapyDevice, &makeUHDSoapyDevice);
-    #endif
 }


### PR DESCRIPTION
## Drop UHD <4.0 support

### Changed

- Remove `UHD_HAS_DEVICE_FILTER`, `UHD_HAS_SET_RX_AGC`, `UHD_HAS_SET_PUBLISHER`, `UHD_HAS_MSG_HPP` feature probes from `CMakeLists.txt`.
- Remove the corresponding `#ifdef` branches in `SoapyUHDDevice.cpp` and `UHDSoapyDevice.cpp`.
- Drop the `publish` / `subscribe` macro shim; rename call sites to `set_publisher` / `add_desired_subscriber` (~30 sites).
- Collapse `_get_tree()` to `_dev->get_tree()` (UHD 4.0+ `multi_usrp` method).
- Drop the `boost::weak_ptr` fallback for streamer caches; standardize on `std::weak_ptr`.
- Require `find_package(UHD 4.0 REQUIRED)`.

### Why

UHD 4.0 shipped September 2020. UHD 3.15 LTS reached EOL 2024-07. Current distros all ship UHD 4.x: Debian bookworm 4.4, trixie 4.7, Ubuntu 22.04 4.1, 24.04 4.6, Homebrew 4.7+. The conditional code is dead in practice and adds ~80 lines of branching for no functional benefit.
