### PR TITLE
Bump CMAKE_CXX_STANDARD to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_minimum_required(VERSION 2.8.12...3.10)
 project(SoapyUHD CXX C)
 enable_testing()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
## Bump CMAKE_CXX_STANDARD to 20

### Changed

- `set(CMAKE_CXX_STANDARD 20)` (was 14).

### Why

Enables `<format>`, designated initializers, ranges, and other C++20 features in this codebase and downstream consumers. Standalone change; supersedes any prior C++17 bump.
