### PR TITLE
Replace Boost with C++ standard library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,10 @@ jobs:
         run: port install SoapySDR py310-setuptools uhd
         # Note: MacPorts uhd depends on non-default boost171
       - name: Configure
-        run:  BOOST_ROOT=/opt/local/libexec/boost/1.71 cmake -B build
+        # MacPorts UHD public headers include <boost/config.hpp>, but its
+        # boost171 dependency lives in a non-default prefix; expose the
+        # include dir here instead of re-adding Boost to the project build.
+        run: BOOST_ROOT=/opt/local/libexec/boost/1.71 cmake -B build -DCMAKE_CXX_FLAGS="-I/opt/local/libexec/boost/1.71/include"
       - name: Build
         run: cmake --build build
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,38 +102,16 @@ else()
 endif()
 
 ########################################################################
-# Setup boost
-########################################################################
-MESSAGE(STATUS "Configuring Boost C++ Libraries...")
-
-if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
-    list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
-endif(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
-
-find_package(Boost)
-
-if(NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost not found -- required for Soapy UHD support")
-endif()
-
-ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
-
-include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIRS})
-
-message(STATUS "Boost include directories: ${Boost_INCLUDE_DIRS}")
-message(STATUS "Boost library directories: ${Boost_LIBRARY_DIRS}")
-message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
-
-########################################################################
 # Build a Soapy module to support UHD devices
 ########################################################################
+# Boost is no longer linked directly; UHD's CMake config still pulls
+# Boost_INCLUDE_DIRS transitively for any UHD public headers that
+# template-instantiate boost types (e.g. uhd::dict in dict.ipp).
 SOAPY_SDR_MODULE_UTIL(
     TARGET uhdSupport
     SOURCES SoapyUHDDevice.cpp
     LIBRARIES
         ${UHD_LIBRARIES}
-        ${Boost_LIBRARIES}
 )
 
 ########################################################################
@@ -142,8 +120,7 @@ SOAPY_SDR_MODULE_UTIL(
 add_library(soapySupport MODULE UHDSoapyDevice.cpp)
 target_link_libraries(soapySupport
     ${UHD_LIBRARIES}
-    ${SoapySDR_LIBRARIES}
-    ${Boost_LIBRARIES})
+    ${SoapySDR_LIBRARIES})
 install(TARGETS soapySupport
     DESTINATION ${UHD_ROOT}/lib${LIB_SUFFIX}/uhd/modules
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,43 +108,20 @@ else()
 endif()
 
 ########################################################################
-# Setup boost
+# Build a Soapy module to support UHD devices
 ########################################################################
-MESSAGE(STATUS "Configuring Boost C++ Libraries...")
-
-if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
-    list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
-endif(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
-
-find_package(Boost)
-
-if(NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost not found -- required for Soapy UHD support")
-endif()
-
-list(APPEND UHD_FEATURE_DEFS BOOST_ALL_DYN_LINK)
-
-message(STATUS "Boost include directories: ${Boost_INCLUDE_DIRS}")
-message(STATUS "Boost library directories: ${Boost_LIBRARY_DIRS}")
-message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
-
 set(SOAPY_UHD_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${SoapySDR_INCLUDE_DIRS}
     ${UHD_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
-########################################################################
-# Build a Soapy module to support UHD devices
-########################################################################
 if(BUILD_UHD_SUPPORT)
     SOAPY_SDR_MODULE_UTIL(
         TARGET uhdSupport
         SOURCES SoapyUHDDevice.cpp
         LIBRARIES
             ${UHD_LIBRARIES}
-            ${Boost_LIBRARIES}
     )
     target_include_directories(uhdSupport PRIVATE ${SOAPY_UHD_INCLUDE_DIRS})
     target_compile_definitions(uhdSupport PRIVATE ${UHD_FEATURE_DEFS})
@@ -159,8 +136,7 @@ if(BUILD_SOAPY_SUPPORT)
     target_compile_definitions(soapySupport PRIVATE ${UHD_FEATURE_DEFS})
     target_link_libraries(soapySupport
         ${UHD_LIBRARIES}
-        ${SoapySDR_LIBRARIES}
-        ${Boost_LIBRARIES})
+        ${SoapySDR_LIBRARIES})
     install(TARGETS soapySupport
         DESTINATION ${UHD_ROOT}/lib${LIB_SUFFIX}/uhd/modules
     )

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -69,7 +69,7 @@ public:
             for (const std::string &key : info.keys())
             {
                 if (key.size() > 3 and key.substr(0, 3) == "tx_")
-                    out[str(boost::format("tx%d_%s") % i % key.substr(3))] = info[key];
+                    out["tx" + std::to_string(i) + "_" + key.substr(3)] = info[key];
                 else out[key] = info[key];
             }
         }
@@ -79,7 +79,7 @@ public:
             for (const std::string &key : info.keys())
             {
                 if (key.size() > 3 and key.substr(0, 3) == "rx_")
-                    out[str(boost::format("rx%d_%s") % i % key.substr(3))] = info[key];
+                    out["rx" + std::to_string(i) + "_" + key.substr(3)] = info[key];
                 else out[key] = info[key];
             }
         }
@@ -718,7 +718,7 @@ public:
         {
             //read the range from the property tree
             uhd::property_tree::sptr tree = _get_tree();
-            const std::string path = str(boost::format("/mboards/0/%s_dsps/%u/freq/range") % ((dir == SOAPY_SDR_TX)?"tx":"rx") % channel);
+            const std::string path = std::string("/mboards/0/") + ((dir == SOAPY_SDR_TX) ? "tx" : "rx") + "_dsps/" + std::to_string(channel) + "/freq/range";
             if (tree->exists(path)) return metaRangeToRangeList(tree->access<uhd::meta_range_t>(path).get());
             else return SoapySDR::RangeList(1, SoapySDR::Range(-getSampleRate(dir, channel)/2, getSampleRate(dir, channel)/2));
         }
@@ -1002,9 +1002,7 @@ public:
                                                 : _dev->get_rx_subdev_spec(0).at(channel);
 
         const std::string path =
-            str(boost::format("/mboards/0/%s_frontends/%s")
-                % directionName
-                % subdevSpec.db_name);
+            "/mboards/0/" + directionName + "_frontends/" + subdevSpec.db_name;
 
         return path;
     }
@@ -1017,10 +1015,7 @@ public:
                                                 : _dev->get_rx_subdev_spec(0).at(channel);
 
         const std::string path =
-            str(boost::format("/mboards/0/dboards/%s/%s_frontends/%s")
-                % subdevSpec.db_name
-                % directionName
-                % subdevSpec.sd_name);
+            "/mboards/0/dboards/" + subdevSpec.db_name + "/" + directionName + "_frontends/" + subdevSpec.sd_name;
 
         return path;
     }
@@ -1144,13 +1139,15 @@ std::vector<SoapySDR::Kwargs> find_uhd(const SoapySDR::Kwargs &args_)
 
 SoapySDR::Device *make_uhd(const SoapySDR::Kwargs &args)
 {
-    if(std::string(UHD_VERSION_ABI_STRING) != uhd::get_abi_string()) throw std::runtime_error(str(boost::format(
-        "SoapySDR detected ABI compatibility mismatch with UHD library.\n"
-        "SoapySDR UHD support was build against ABI: %s,\n"
-        "but UHD library reports ABI: %s\n"
-        "Suggestion: install an ABI compatible version of UHD,\n"
-        "or rebuild SoapySDR UHD support against this ABI version.\n"
-    ) % UHD_VERSION_ABI_STRING % uhd::get_abi_string()));
+    if (std::string(UHD_VERSION_ABI_STRING) != uhd::get_abi_string())
+    {
+        throw std::runtime_error(
+            std::string("SoapySDR detected ABI compatibility mismatch with UHD library.\n")
+            + "SoapySDR UHD support was build against ABI: " + UHD_VERSION_ABI_STRING + ",\n"
+            + "but UHD library reports ABI: " + uhd::get_abi_string() + "\n"
+            + "Suggestion: install an ABI compatible version of UHD,\n"
+            + "or rebuild SoapySDR UHD support against this ABI version.\n");
+    }
     #ifdef UHD_HAS_MSG_HPP
     uhd::msg::register_handler(&SoapyUHDLogger);
     #else

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -613,13 +613,13 @@ public:
 
         if (args.count("OFFSET") != 0)
         {
-            tr = uhd::tune_request_t(frequency, boost::lexical_cast<double>(args.at("OFFSET")));
+            tr = uhd::tune_request_t(frequency, std::stod(args.at("OFFSET")));
         }
         if (args.count("RF") != 0)
         {
             try
             {
-                tr.rf_freq = boost::lexical_cast<double>(args.at("RF"));
+                tr.rf_freq = std::stod(args.at("RF"));
                 tr.rf_freq_policy = uhd::tune_request_t::POLICY_MANUAL;
             }
             catch (...)
@@ -631,7 +631,7 @@ public:
         {
             try
             {
-                tr.dsp_freq = boost::lexical_cast<double>(args.at("BB"));
+                tr.dsp_freq = std::stod(args.at("BB"));
                 tr.dsp_freq_policy = uhd::tune_request_t::POLICY_MANUAL;
             }
             catch (...)

--- a/SoapyUHDDevice.cpp
+++ b/SoapyUHDDevice.cpp
@@ -16,7 +16,6 @@
 #include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/property_tree.hpp>
 #include <uhd/version.hpp>
-#include <boost/lexical_cast.hpp>
 #include <cctype>
 #include <iostream>
 
@@ -67,7 +66,7 @@ public:
             for (const std::string &key : info.keys())
             {
                 if (key.size() > 3 and key.substr(0, 3) == "tx_")
-                    out[str(boost::format("tx%d_%s") % i % key.substr(3))] = info[key];
+                    out["tx" + std::to_string(i) + "_" + key.substr(3)] = info[key];
                 else out[key] = info[key];
             }
         }
@@ -77,7 +76,7 @@ public:
             for (const std::string &key : info.keys())
             {
                 if (key.size() > 3 and key.substr(0, 3) == "rx_")
-                    out[str(boost::format("rx%d_%s") % i % key.substr(3))] = info[key];
+                    out["rx" + std::to_string(i) + "_" + key.substr(3)] = info[key];
                 else out[key] = info[key];
             }
         }
@@ -631,13 +630,13 @@ public:
 
         if (args.count("OFFSET") != 0)
         {
-            tr = uhd::tune_request_t(frequency, boost::lexical_cast<double>(args.at("OFFSET")));
+            tr = uhd::tune_request_t(frequency, std::stod(args.at("OFFSET")));
         }
         if (args.count("RF") != 0)
         {
             try
             {
-                tr.rf_freq = boost::lexical_cast<double>(args.at("RF"));
+                tr.rf_freq = std::stod(args.at("RF"));
                 tr.rf_freq_policy = uhd::tune_request_t::POLICY_MANUAL;
             }
             catch (...)
@@ -649,7 +648,7 @@ public:
         {
             try
             {
-                tr.dsp_freq = boost::lexical_cast<double>(args.at("BB"));
+                tr.dsp_freq = std::stod(args.at("BB"));
                 tr.dsp_freq_policy = uhd::tune_request_t::POLICY_MANUAL;
             }
             catch (...)
@@ -736,7 +735,7 @@ public:
         {
             //read the range from the property tree
             uhd::property_tree::sptr tree = _get_tree();
-            const std::string path = str(boost::format("/mboards/0/%s_dsps/%u/freq/range") % ((dir == SOAPY_SDR_TX)?"tx":"rx") % channel);
+            const std::string path = std::string("/mboards/0/") + ((dir == SOAPY_SDR_TX) ? "tx" : "rx") + "_dsps/" + std::to_string(channel) + "/freq/range";
             if (tree->exists(path)) return metaRangeToRangeList(tree->access<uhd::meta_range_t>(path).get());
             else return SoapySDR::RangeList(1, SoapySDR::Range(-getSampleRate(dir, channel)/2, getSampleRate(dir, channel)/2));
         }
@@ -1020,9 +1019,7 @@ public:
                                                 : _dev->get_rx_subdev_spec(0).at(channel);
 
         const std::string path =
-            str(boost::format("/mboards/0/%s_frontends/%s")
-                % directionName
-                % subdevSpec.db_name);
+            "/mboards/0/" + directionName + "_frontends/" + subdevSpec.db_name;
 
         return path;
     }
@@ -1035,10 +1032,7 @@ public:
                                                 : _dev->get_rx_subdev_spec(0).at(channel);
 
         const std::string path =
-            str(boost::format("/mboards/0/dboards/%s/%s_frontends/%s")
-                % subdevSpec.db_name
-                % directionName
-                % subdevSpec.sd_name);
+            "/mboards/0/dboards/" + subdevSpec.db_name + "/" + directionName + "_frontends/" + subdevSpec.sd_name;
 
         return path;
     }
@@ -1139,13 +1133,15 @@ std::vector<SoapySDR::Kwargs> find_uhd(const SoapySDR::Kwargs &args_)
 
 SoapySDR::Device *make_uhd(const SoapySDR::Kwargs &args)
 {
-    if(std::string(UHD_VERSION_ABI_STRING) != uhd::get_abi_string()) throw std::runtime_error(str(boost::format(
-        "SoapySDR detected ABI compatibility mismatch with UHD library.\n"
-        "SoapySDR UHD support was build against ABI: %s,\n"
-        "but UHD library reports ABI: %s\n"
-        "Suggestion: install an ABI compatible version of UHD,\n"
-        "or rebuild SoapySDR UHD support against this ABI version.\n"
-    ) % UHD_VERSION_ABI_STRING % uhd::get_abi_string()));
+    if (std::string(UHD_VERSION_ABI_STRING) != uhd::get_abi_string())
+    {
+        throw std::runtime_error(
+            std::string("SoapySDR detected ABI compatibility mismatch with UHD library.\n")
+            + "SoapySDR UHD support was build against ABI: " + UHD_VERSION_ABI_STRING + ",\n"
+            + "but UHD library reports ABI: " + uhd::get_abi_string() + "\n"
+            + "Suggestion: install an ABI compatible version of UHD,\n"
+            + "or rebuild SoapySDR UHD support against this ABI version.\n");
+    }
     uhd::log::add_logger("SoapyUHDDevice", &SoapyUHDLogger);
     return new SoapyUHDDevice(uhd::usrp::multi_usrp::make(kwargsToDict(args)), args);
 }

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -33,7 +33,6 @@
 
 #include <boost/foreach.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/bind.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -223,45 +222,45 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 
     //the frontend mapping
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "rx_subdev_spec")
-        .publish(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_RX))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_RX, _1));
+        .publish([this]() { return get_frontend_mapping(SOAPY_SDR_RX); })
+        .subscribe([this](auto&& v) { return set_frontend_mapping(SOAPY_SDR_RX, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "tx_subdev_spec")
-        .publish(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_TX))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_TX, _1));
+        .publish([this]() { return get_frontend_mapping(SOAPY_SDR_TX); })
+        .subscribe([this](auto&& v) { return set_frontend_mapping(SOAPY_SDR_TX, std::forward<decltype(v)>(v)); });
 
     //timed command support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "cmd")
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "CMD", _1));
+        .subscribe([this](auto&& v) { return set_hardware_time("CMD", std::forward<decltype(v)>(v)); });
     _tree->create<double>(mb_path / "tick_rate")
-        .publish(boost::bind(&SoapySDR::Device::getMasterClockRate, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setMasterClockRate, _device, _1));
+        .publish([d=_device]() { return d->getMasterClockRate(); })
+        .subscribe([d=_device](auto&& v) { return d->setMasterClockRate(std::forward<decltype(v)>(v)); });
 
     //hardware time support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "now")
-        .publish(boost::bind(&UHDSoapyDevice::get_hardware_time, this, ""))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "", _1));
+        .publish([this]() { return get_hardware_time(""); })
+        .subscribe([this](auto&& v) { return set_hardware_time("", std::forward<decltype(v)>(v)); });
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "pps")
-        .publish(boost::bind(&UHDSoapyDevice::get_hardware_time, this, "PPS"))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "PPS", _1));
+        .publish([this]() { return get_hardware_time("PPS"); })
+        .subscribe([this](auto&& v) { return set_hardware_time("PPS", std::forward<decltype(v)>(v)); });
 
     //clock and time sources
     _tree->create<std::vector<std::string> >(mb_path / "clock_source"/ "options")
-        .publish(boost::bind(&SoapySDR::Device::listClockSources, _device));
+        .publish([d=_device]() { return d->listClockSources(); });
     _tree->create<std::string>(mb_path / "clock_source" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getClockSource, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setClockSource, _device, _1));
+        .publish([d=_device]() { return d->getClockSource(); })
+        .subscribe([d=_device](auto&& v) { return d->setClockSource(std::forward<decltype(v)>(v)); });
     _tree->create<std::vector<std::string> >(mb_path / "time_source"/ "options")
-        .publish(boost::bind(&SoapySDR::Device::listTimeSources, _device));
+        .publish([d=_device]() { return d->listTimeSources(); });
     _tree->create<std::string>(mb_path / "time_source" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getTimeSource, _device))
-        .subscribe(boost::bind(&SoapySDR::Device::setTimeSource, _device, _1));
+        .publish([d=_device]() { return d->getTimeSource(); })
+        .subscribe([d=_device](auto&& v) { return d->setTimeSource(std::forward<decltype(v)>(v)); });
 
     //mboard sensors
     _tree->create<int>(mb_path / "sensors"); //ensure this path exists
     for(const std::string &name : _device->listSensors())
     {
         _tree->create<uhd::sensor_value_t>(mb_path / "sensors" / name)
-            .publish(boost::bind(&UHDSoapyDevice::get_mboard_sensor, this, name));
+            .publish([this, name]() { return get_mboard_sensor(name); });
     }
 
     //gpio banks
@@ -279,8 +278,8 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
         for(const std::string &attr : attrs)
         {
             _tree->create<boost::uint32_t>(mb_path / "gpio" / bank / attr)
-                .subscribe(boost::bind(&UHDSoapyDevice::set_gpio_attr, this, bank, attr, _1))
-                .publish(boost::bind(&UHDSoapyDevice::get_gpio_attr, this, bank, attr));
+                .subscribe([this, bank, attr](auto&& v) { return set_gpio_attr(bank, attr, std::forward<decltype(v)>(v)); })
+                .publish([this, bank, attr]() { return get_gpio_attr(bank, attr); });
         }
     }
 
@@ -341,10 +340,10 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
 
     //samp rate
     _tree->create<uhd::meta_range_t>(dsp_path / "rate" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_rate_range, this, dir, chan));
+        .publish([this, dir, chan]() { return get_rate_range(dir, chan); });
     _tree->create<double>(dsp_path / "rate" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getSampleRate, _device, dir, chan))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_sample_rate, this, dir, chan, _1));
+        .publish([d=_device, dir, chan]() { return d->getSampleRate(dir, chan); })
+        .subscribe([this, dir, chan](auto&& v) { return set_sample_rate(dir, chan, std::forward<decltype(v)>(v)); });
 
     //dsp freq (when there is no tunable cordic)
     if (bbCompName.empty())
@@ -356,17 +355,17 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     else
     {
         _tree->create<double>(dsp_path / "freq" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, bbCompName))
-            .subscribe(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, bbCompName, _1));
+            .publish([d=_device, dir, chan, bbCompName]() { return d->getFrequency(dir, chan, bbCompName); })
+            .subscribe([this, dir, chan, bbCompName](auto&& v) { return set_frequency(dir, chan, bbCompName, std::forward<decltype(v)>(v)); });
         _tree->create<uhd::meta_range_t>(dsp_path / "freq" / "range")
-            .publish(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, bbCompName));
+            .publish([this, dir, chan, bbCompName]() { return get_freq_range(dir, chan, bbCompName); });
     }
 
     //old style stream cmd
     if (dir == SOAPY_SDR_RX)
     {
         _tree->create<uhd::stream_cmd_t>(dsp_path / "stream_cmd")
-            .subscribe(boost::bind(&UHDSoapyDevice::old_issue_stream_cmd, this, chan, _1));
+            .subscribe([this, chan](auto&& v) { return old_issue_stream_cmd(chan, std::forward<decltype(v)>(v)); });
     }
 
     //frontend sensors
@@ -375,7 +374,7 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     {
         //install the sensor
         _tree->create<uhd::sensor_value_t>(rf_fe_path / "sensors" / name)
-            .publish(boost::bind(&UHDSoapyDevice::get_channel_sensor, this, dir, chan, name));
+            .publish([this, dir, chan, name]() { return get_channel_sensor(dir, chan, name); });
     }
 
     //dummy eeprom values
@@ -396,69 +395,69 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     for(const std::string &name : _device->listGains(dir, chan))
     {
         _tree->create<uhd::meta_range_t>(rf_fe_path / "gains" / name / "range")
-            .publish(boost::bind(&UHDSoapyDevice::get_gain_range, this, dir, chan, name));
+            .publish([this, dir, chan, name]() { return get_gain_range(dir, chan, name); });
         _tree->create<double>(rf_fe_path / "gains" / name / "value")
-            .publish(boost::bind(&SoapySDR::Device::getGain, _device, dir, chan, name))
-            .subscribe(boost::bind(&SoapySDR::Device::setGain, _device, dir, chan, name, _1));
+            .publish([d=_device, dir, chan, name]() { return d->getGain(dir, chan, name); })
+            .subscribe([d=_device, dir, chan, name](auto&& v) { return d->setGain(dir, chan, name, std::forward<decltype(v)>(v)); });
     }
 
     //agc
     _tree->create<bool>(rf_fe_path / "gain" / "agc" / "enable")
-        .publish(boost::bind(&SoapySDR::Device::getGainMode, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setGainMode, _device, dir, chan, _1));
+        .publish([d=_device, dir, chan]() { return d->getGainMode(dir, chan); })
+        .subscribe([d=_device, dir, chan](auto&& v) { return d->setGainMode(dir, chan, std::forward<decltype(v)>(v)); });
 
     //freq
     _tree->create<double>(rf_fe_path / "freq" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, rfCompName))
-        .subscribe(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, rfCompName, _1));
+        .publish([d=_device, dir, chan, rfCompName]() { return d->getFrequency(dir, chan, rfCompName); })
+        .subscribe([this, dir, chan, rfCompName](auto&& v) { return set_frequency(dir, chan, rfCompName, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::meta_range_t>(rf_fe_path / "freq" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, rfCompName));
+        .publish([this, dir, chan, rfCompName]() { return get_freq_range(dir, chan, rfCompName); });
     _tree->create<bool>(rf_fe_path / "use_lo_offset").set(false);
     _tree->create<uhd::device_addr_t>(rf_fe_path / "tune_args")
-        .subscribe(boost::bind(&UHDSoapyDevice::stash_tune_args, this, dir, chan, _1));
+        .subscribe([this, dir, chan](auto&& v) { return stash_tune_args(dir, chan, std::forward<decltype(v)>(v)); });
 
     //ant
     _tree->create<std::vector<std::string> >(rf_fe_path / "antenna" / "options")
-        .publish(boost::bind(&SoapySDR::Device::listAntennas, _device, dir, chan));
+        .publish([d=_device, dir, chan]() { return d->listAntennas(dir, chan); });
     _tree->create<std::string>(rf_fe_path / "antenna" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getAntenna, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setAntenna, _device, dir, chan, _1));
+        .publish([d=_device, dir, chan]() { return d->getAntenna(dir, chan); })
+        .subscribe([d=_device, dir, chan](auto&& v) { return d->setAntenna(dir, chan, std::forward<decltype(v)>(v)); });
 
     //bw
     _tree->create<double>(rf_fe_path / "bandwidth" / "value")
-        .publish(boost::bind(&SoapySDR::Device::getBandwidth, _device, dir, chan))
-        .subscribe(boost::bind(&SoapySDR::Device::setBandwidth, _device, dir, chan, _1));
+        .publish([d=_device, dir, chan]() { return d->getBandwidth(dir, chan); })
+        .subscribe([d=_device, dir, chan](auto&& v) { return d->setBandwidth(dir, chan, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::meta_range_t>(rf_fe_path / "bandwidth" / "range")
-        .publish(boost::bind(&UHDSoapyDevice::get_bw_range, this, dir, chan));
+        .publish([this, dir, chan]() { return get_bw_range(dir, chan); });
 
     //corrections
     if (_device->hasDCOffsetMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "dc_offset" / "enable")
-            .publish(boost::bind(&SoapySDR::Device::getDCOffsetMode, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setDCOffsetMode, _device, dir, chan, _1));
+            .publish([d=_device, dir, chan]() { return d->getDCOffsetMode(dir, chan); })
+            .subscribe([d=_device, dir, chan](auto&& v) { return d->setDCOffsetMode(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     if (_device->hasDCOffset(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "dc_offset" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getDCOffset, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setDCOffset, _device, dir, chan, _1));
+            .publish([d=_device, dir, chan]() { return d->getDCOffset(dir, chan); })
+            .subscribe([d=_device, dir, chan](auto&& v) { return d->setDCOffset(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     if (_device->hasIQBalance(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "iq_balance" / "value")
-            .publish(boost::bind(&SoapySDR::Device::getIQBalance, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setIQBalance, _device, dir, chan, _1));
+            .publish([d=_device, dir, chan]() { return d->getIQBalance(dir, chan); })
+            .subscribe([d=_device, dir, chan](auto&& v) { return d->setIQBalance(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     #ifdef SOAPY_SDR_API_HAS_IQ_BALANCE_MODE
     if (_device->hasIQBalanceMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "iq_balance" / "enable")
-            .publish(boost::bind(&SoapySDR::Device::getIQBalanceMode, _device, dir, chan))
-            .subscribe(boost::bind(&SoapySDR::Device::setIQBalanceMode, _device, dir, chan, _1));
+            .publish([d=_device, dir, chan]() { return d->getIQBalanceMode(dir, chan); })
+            .subscribe([d=_device, dir, chan](auto&& v) { return d->setIQBalanceMode(dir, chan, std::forward<decltype(v)>(v)); });
     }
     #endif
 }

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -32,7 +32,6 @@
 #include <SoapySDR/Logger.hpp>
 
 #include <boost/foreach.hpp>
-#include <boost/format.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/bind.hpp>
 #include <boost/weak_ptr.hpp>
@@ -704,7 +703,7 @@ public:
         int ret = 0;
         if (activate) ret = _device->activateStream(_stream, flags, timeNs, numElems);
         else ret = _device->deactivateStream(_stream, flags, timeNs);
-        if (ret != 0) throw std::runtime_error(str(boost::format("UHDSoapyRxStream::issue_stream_cmd() = %d") % ret));
+        if (ret != 0) throw std::runtime_error("UHDSoapyRxStream::issue_stream_cmd() = " + std::to_string(ret));
     }
 
     #if UHD_VERSION >= 4080000
@@ -794,7 +793,7 @@ public:
             for (size_t i = 0; i < _nchan; i++) _offsetBuffs[i] = ((char *)buffs[i]) + total*_elemSize;
             int ret = _device->writeStream(_stream, &(_offsetBuffs[0]), numElems, flags, timeNs, long(timeout*1e6));
             if (ret == SOAPY_SDR_TIMEOUT) break;
-            if (ret < 0) throw std::runtime_error(str(boost::format("UHDSoapyTxStream::send() = %d") % ret));
+            if (ret < 0) throw std::runtime_error("UHDSoapyTxStream::send() = " + std::to_string(ret));
             total += ret;
         }
 

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -75,7 +75,7 @@ public:
         uhd::usrp::subdev_spec_t spec;
         for (size_t ch = 0; ch < _device->getNumChannels(dir); ch++)
         {
-            const std::string chName(boost::lexical_cast<std::string>(ch));
+            const std::string chName(std::to_string(ch));
             spec.push_back(uhd::usrp::subdev_spec_pair_t(chName, chName));
         }
 
@@ -309,7 +309,7 @@ void UHDSoapyDevice::setupChannelHooks()
 
     for (size_t ch = 0; ch < numChannels; ch++)
     {
-        const std::string chName(boost::lexical_cast<std::string>(ch));
+        const std::string chName(std::to_string(ch));
         if (ch < numRxChannels)
             this->setupChannelHooks(SOAPY_SDR_RX, ch, kRxDirName, chName);
         else

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -31,10 +31,10 @@
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Logger.hpp>
 
-#include <boost/foreach.hpp>
-#include <boost/thread/mutex.hpp>
+#include <cstdint>
+#include <mutex>
+
 #include <boost/weak_ptr.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -158,7 +158,7 @@ public:
     void setupChannelHooks(const int dir, const size_t chan, const std::string &dirName, const std::string &chName);
     void setupFakeChannelHooks(const int dir, const size_t chan, const std::string &dirName, const std::string &chName);
 
-    void set_gpio_attr(const std::string &bank, const std::string &attr, const boost::uint32_t value)
+    void set_gpio_attr(const std::string &bank, const std::string &attr, const std::uint32_t value)
     {
         if (attr == "READBACK") return; //readback is never written
         if (attr == "OUT") return _device->writeGPIO(bank, value);
@@ -166,7 +166,7 @@ public:
         return _device->writeGPIO(bank+":"+attr, value);
     }
 
-    boost::uint32_t get_gpio_attr(const std::string &bank, const std::string &attr)
+    std::uint32_t get_gpio_attr(const std::string &bank, const std::string &attr)
     {
         if (attr == "READBACK") return _device->readGPIO(bank);
         if (attr == "OUT") return _device->readGPIO(bank); //usually OUT is cached output setting
@@ -191,16 +191,16 @@ private:
 /***********************************************************************
  * Factory and initialization
  **********************************************************************/
-static boost::mutex &suMutexMaker(void)
+static std::mutex &suMutexMaker(void)
 {
-    static boost::mutex m;
+    static std::mutex m;
     return m;
 }
 
 UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 {
     {
-        boost::mutex::scoped_lock l(suMutexMaker());
+        std::lock_guard<std::mutex> l(suMutexMaker());
         _device = SoapySDR::Device::make(dictToKwargs(args));
     }
 
@@ -277,7 +277,7 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
         attrs.push_back("READBACK");
         for(const std::string &attr : attrs)
         {
-            _tree->create<boost::uint32_t>(mb_path / "gpio" / bank / attr)
+            _tree->create<std::uint32_t>(mb_path / "gpio" / bank / attr)
                 .subscribe([this, bank, attr](auto&& v) { return set_gpio_attr(bank, attr, std::forward<decltype(v)>(v)); })
                 .publish([this, bank, attr]() { return get_gpio_attr(bank, attr); });
         }
@@ -289,7 +289,7 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 
 UHDSoapyDevice::~UHDSoapyDevice(void)
 {
-    boost::mutex::scoped_lock l(suMutexMaker());
+    std::lock_guard<std::mutex> l(suMutexMaker());
     SoapySDR::Device::unmake(_device);
 }
 

--- a/UHDSoapyDevice.cpp
+++ b/UHDSoapyDevice.cpp
@@ -22,13 +22,8 @@
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Logger.hpp>
 
-#include <boost/foreach.hpp>
-#include <boost/format.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/bind.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/weak_ptr.hpp>
-#include <boost/algorithm/string.hpp>
+#include <cstdint>
+#include <mutex>
 
 #include <algorithm>
 #include <cctype>
@@ -67,7 +62,7 @@ public:
         uhd::usrp::subdev_spec_t spec;
         for (size_t ch = 0; ch < _device->getNumChannels(dir); ch++)
         {
-            const std::string chName(boost::lexical_cast<std::string>(ch));
+            const std::string chName(std::to_string(ch));
             spec.push_back(uhd::usrp::subdev_spec_pair_t(chName, chName));
         }
 
@@ -144,7 +139,7 @@ public:
     void setupChannelHooks(const int dir, const size_t chan, const std::string &dirName, const std::string &chName);
     void setupFakeChannelHooks(const int dir, const size_t chan, const std::string &dirName, const std::string &chName);
 
-    void set_gpio_attr(const std::string &bank, const std::string &attr, const boost::uint32_t value)
+    void set_gpio_attr(const std::string &bank, const std::string &attr, const std::uint32_t value)
     {
         if (attr == "READBACK") return; //readback is never written
         if (attr == "OUT") return _device->writeGPIO(bank, value);
@@ -152,7 +147,7 @@ public:
         return _device->writeGPIO(bank+":"+attr, value);
     }
 
-    boost::uint32_t get_gpio_attr(const std::string &bank, const std::string &attr)
+    std::uint32_t get_gpio_attr(const std::string &bank, const std::string &attr)
     {
         if (attr == "READBACK") return _device->readGPIO(bank);
         if (attr == "OUT") return _device->readGPIO(bank); //usually OUT is cached output setting
@@ -172,16 +167,16 @@ private:
 /***********************************************************************
  * Factory and initialization
  **********************************************************************/
-static boost::mutex &suMutexMaker(void)
+static std::mutex &suMutexMaker(void)
 {
-    static boost::mutex m;
+    static std::mutex m;
     return m;
 }
 
 UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 {
     {
-        boost::mutex::scoped_lock l(suMutexMaker());
+        std::lock_guard<std::mutex> l(suMutexMaker());
         _device = SoapySDR::Device::make(dictToKwargs(args));
     }
 
@@ -203,45 +198,45 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 
     //the frontend mapping
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "rx_subdev_spec")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_RX))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_RX, _1));
+        .set_publisher([this]() { return get_frontend_mapping(SOAPY_SDR_RX); })
+        .add_desired_subscriber([this](auto&& v) { return set_frontend_mapping(SOAPY_SDR_RX, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::usrp::subdev_spec_t>(mb_path / "tx_subdev_spec")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_frontend_mapping, this, SOAPY_SDR_TX))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frontend_mapping, this, SOAPY_SDR_TX, _1));
+        .set_publisher([this]() { return get_frontend_mapping(SOAPY_SDR_TX); })
+        .add_desired_subscriber([this](auto&& v) { return set_frontend_mapping(SOAPY_SDR_TX, std::forward<decltype(v)>(v)); });
 
     //timed command support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "cmd")
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "CMD", _1));
+        .add_desired_subscriber([this](auto&& v) { return set_hardware_time("CMD", std::forward<decltype(v)>(v)); });
     _tree->create<double>(mb_path / "tick_rate")
-        .set_publisher(boost::bind(&SoapySDR::Device::getMasterClockRate, _device))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setMasterClockRate, _device, _1));
+        .set_publisher([d=_device]() { return d->getMasterClockRate(); })
+        .add_desired_subscriber([d=_device](auto&& v) { return d->setMasterClockRate(std::forward<decltype(v)>(v)); });
 
     //hardware time support
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "now")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_hardware_time, this, ""))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "", _1));
+        .set_publisher([this]() { return get_hardware_time(""); })
+        .add_desired_subscriber([this](auto&& v) { return set_hardware_time("", std::forward<decltype(v)>(v)); });
     _tree->create<uhd::time_spec_t>(mb_path / "time" / "pps")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_hardware_time, this, "PPS"))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_hardware_time, this, "PPS", _1));
+        .set_publisher([this]() { return get_hardware_time("PPS"); })
+        .add_desired_subscriber([this](auto&& v) { return set_hardware_time("PPS", std::forward<decltype(v)>(v)); });
 
     //clock and time sources
     _tree->create<std::vector<std::string> >(mb_path / "clock_source"/ "options")
-        .set_publisher(boost::bind(&SoapySDR::Device::listClockSources, _device));
+        .set_publisher([d=_device]() { return d->listClockSources(); });
     _tree->create<std::string>(mb_path / "clock_source" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getClockSource, _device))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setClockSource, _device, _1));
+        .set_publisher([d=_device]() { return d->getClockSource(); })
+        .add_desired_subscriber([d=_device](auto&& v) { return d->setClockSource(std::forward<decltype(v)>(v)); });
     _tree->create<std::vector<std::string> >(mb_path / "time_source"/ "options")
-        .set_publisher(boost::bind(&SoapySDR::Device::listTimeSources, _device));
+        .set_publisher([d=_device]() { return d->listTimeSources(); });
     _tree->create<std::string>(mb_path / "time_source" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getTimeSource, _device))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setTimeSource, _device, _1));
+        .set_publisher([d=_device]() { return d->getTimeSource(); })
+        .add_desired_subscriber([d=_device](auto&& v) { return d->setTimeSource(std::forward<decltype(v)>(v)); });
 
     //mboard sensors
     _tree->create<int>(mb_path / "sensors"); //ensure this path exists
     for(const std::string &name : _device->listSensors())
     {
         _tree->create<uhd::sensor_value_t>(mb_path / "sensors" / name)
-            .set_publisher(boost::bind(&UHDSoapyDevice::get_mboard_sensor, this, name));
+            .set_publisher([this, name]() { return get_mboard_sensor(name); });
     }
 
     //gpio banks
@@ -258,9 +253,9 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
         attrs.push_back("READBACK");
         for(const std::string &attr : attrs)
         {
-            _tree->create<boost::uint32_t>(mb_path / "gpio" / bank / attr)
-                .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_gpio_attr, this, bank, attr, _1))
-                .set_publisher(boost::bind(&UHDSoapyDevice::get_gpio_attr, this, bank, attr));
+            _tree->create<std::uint32_t>(mb_path / "gpio" / bank / attr)
+                .add_desired_subscriber([this, bank, attr](auto&& v) { return set_gpio_attr(bank, attr, std::forward<decltype(v)>(v)); })
+                .set_publisher([this, bank, attr]() { return get_gpio_attr(bank, attr); });
         }
     }
 
@@ -270,7 +265,7 @@ UHDSoapyDevice::UHDSoapyDevice(const uhd::device_addr_t &args)
 
 UHDSoapyDevice::~UHDSoapyDevice(void)
 {
-    boost::mutex::scoped_lock l(suMutexMaker());
+    std::lock_guard<std::mutex> l(suMutexMaker());
     SoapySDR::Device::unmake(_device);
 }
 
@@ -288,7 +283,7 @@ void UHDSoapyDevice::setupChannelHooks()
 
     for (size_t ch = 0; ch < numChannels; ch++)
     {
-        const std::string chName(boost::lexical_cast<std::string>(ch));
+        const std::string chName(std::to_string(ch));
         if (ch < numRxChannels)
             this->setupChannelHooks(SOAPY_SDR_RX, ch, kRxDirName, chName);
         else
@@ -321,10 +316,10 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
 
     //samp rate
     _tree->create<uhd::meta_range_t>(dsp_path / "rate" / "range")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_rate_range, this, dir, chan));
+        .set_publisher([this, dir, chan]() { return get_rate_range(dir, chan); });
     _tree->create<double>(dsp_path / "rate" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getSampleRate, _device, dir, chan))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_sample_rate, this, dir, chan, _1));
+        .set_publisher([d=_device, dir, chan]() { return d->getSampleRate(dir, chan); })
+        .add_desired_subscriber([this, dir, chan](auto&& v) { return set_sample_rate(dir, chan, std::forward<decltype(v)>(v)); });
 
     //dsp freq (when there is no tunable cordic)
     if (bbCompName.empty())
@@ -336,17 +331,17 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     else
     {
         _tree->create<double>(dsp_path / "freq" / "value")
-            .set_publisher(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, bbCompName))
-            .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, bbCompName, _1));
+            .set_publisher([d=_device, dir, chan, bbCompName]() { return d->getFrequency(dir, chan, bbCompName); })
+            .add_desired_subscriber([this, dir, chan, bbCompName](auto&& v) { return set_frequency(dir, chan, bbCompName, std::forward<decltype(v)>(v)); });
         _tree->create<uhd::meta_range_t>(dsp_path / "freq" / "range")
-            .set_publisher(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, bbCompName));
+            .set_publisher([this, dir, chan, bbCompName]() { return get_freq_range(dir, chan, bbCompName); });
     }
 
     //old style stream cmd
     if (dir == SOAPY_SDR_RX)
     {
         _tree->create<uhd::stream_cmd_t>(dsp_path / "stream_cmd")
-            .add_desired_subscriber(boost::bind(&UHDSoapyDevice::old_issue_stream_cmd, this, chan, _1));
+            .add_desired_subscriber([this, chan](auto&& v) { return old_issue_stream_cmd(chan, std::forward<decltype(v)>(v)); });
     }
 
     //frontend sensors
@@ -355,7 +350,7 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     {
         //install the sensor
         _tree->create<uhd::sensor_value_t>(rf_fe_path / "sensors" / name)
-            .set_publisher(boost::bind(&UHDSoapyDevice::get_channel_sensor, this, dir, chan, name));
+            .set_publisher([this, dir, chan, name]() { return get_channel_sensor(dir, chan, name); });
     }
 
     //dummy eeprom values
@@ -376,68 +371,68 @@ void UHDSoapyDevice::setupChannelHooks(const int dir, const size_t chan, const s
     for(const std::string &name : _device->listGains(dir, chan))
     {
         _tree->create<uhd::meta_range_t>(rf_fe_path / "gains" / name / "range")
-            .set_publisher(boost::bind(&UHDSoapyDevice::get_gain_range, this, dir, chan, name));
+            .set_publisher([this, dir, chan, name]() { return get_gain_range(dir, chan, name); });
         _tree->create<double>(rf_fe_path / "gains" / name / "value")
-            .set_publisher(boost::bind(&SoapySDR::Device::getGain, _device, dir, chan, name))
-            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setGain, _device, dir, chan, name, _1));
+            .set_publisher([d=_device, dir, chan, name]() { return d->getGain(dir, chan, name); })
+            .add_desired_subscriber([d=_device, dir, chan, name](auto&& v) { return d->setGain(dir, chan, name, std::forward<decltype(v)>(v)); });
     }
 
     //agc
     _tree->create<bool>(rf_fe_path / "gain" / "agc" / "enable")
-        .set_publisher(boost::bind(&SoapySDR::Device::getGainMode, _device, dir, chan))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setGainMode, _device, dir, chan, _1));
+        .set_publisher([d=_device, dir, chan]() { return d->getGainMode(dir, chan); })
+        .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setGainMode(dir, chan, std::forward<decltype(v)>(v)); });
 
     //freq
     _tree->create<double>(rf_fe_path / "freq" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getFrequency, _device, dir, chan, rfCompName))
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::set_frequency, this, dir, chan, rfCompName, _1));
+        .set_publisher([d=_device, dir, chan, rfCompName]() { return d->getFrequency(dir, chan, rfCompName); })
+        .add_desired_subscriber([this, dir, chan, rfCompName](auto&& v) { return set_frequency(dir, chan, rfCompName, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::meta_range_t>(rf_fe_path / "freq" / "range")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_freq_range, this, dir, chan, rfCompName));
+        .set_publisher([this, dir, chan, rfCompName]() { return get_freq_range(dir, chan, rfCompName); });
     _tree->create<bool>(rf_fe_path / "use_lo_offset").set(false);
     _tree->create<uhd::device_addr_t>(rf_fe_path / "tune_args")
-        .add_desired_subscriber(boost::bind(&UHDSoapyDevice::stash_tune_args, this, dir, chan, _1));
+        .add_desired_subscriber([this, dir, chan](auto&& v) { return stash_tune_args(dir, chan, std::forward<decltype(v)>(v)); });
 
     //ant
     _tree->create<std::vector<std::string> >(rf_fe_path / "antenna" / "options")
-        .set_publisher(boost::bind(&SoapySDR::Device::listAntennas, _device, dir, chan));
+        .set_publisher([d=_device, dir, chan]() { return d->listAntennas(dir, chan); });
     _tree->create<std::string>(rf_fe_path / "antenna" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getAntenna, _device, dir, chan))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setAntenna, _device, dir, chan, _1));
+        .set_publisher([d=_device, dir, chan]() { return d->getAntenna(dir, chan); })
+        .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setAntenna(dir, chan, std::forward<decltype(v)>(v)); });
 
     //bw
     _tree->create<double>(rf_fe_path / "bandwidth" / "value")
-        .set_publisher(boost::bind(&SoapySDR::Device::getBandwidth, _device, dir, chan))
-        .add_desired_subscriber(boost::bind(&SoapySDR::Device::setBandwidth, _device, dir, chan, _1));
+        .set_publisher([d=_device, dir, chan]() { return d->getBandwidth(dir, chan); })
+        .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setBandwidth(dir, chan, std::forward<decltype(v)>(v)); });
     _tree->create<uhd::meta_range_t>(rf_fe_path / "bandwidth" / "range")
-        .set_publisher(boost::bind(&UHDSoapyDevice::get_bw_range, this, dir, chan));
+        .set_publisher([this, dir, chan]() { return get_bw_range(dir, chan); });
 
     //corrections
     if (_device->hasDCOffsetMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "dc_offset" / "enable")
-            .set_publisher(boost::bind(&SoapySDR::Device::getDCOffsetMode, _device, dir, chan))
-            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setDCOffsetMode, _device, dir, chan, _1));
+            .set_publisher([d=_device, dir, chan]() { return d->getDCOffsetMode(dir, chan); })
+            .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setDCOffsetMode(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     if (_device->hasDCOffset(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "dc_offset" / "value")
-            .set_publisher(boost::bind(&SoapySDR::Device::getDCOffset, _device, dir, chan))
-            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setDCOffset, _device, dir, chan, _1));
+            .set_publisher([d=_device, dir, chan]() { return d->getDCOffset(dir, chan); })
+            .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setDCOffset(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     if (_device->hasIQBalance(dir, chan))
     {
         _tree->create<std::complex<double>>(rf_fe_path / "iq_balance" / "value")
-            .set_publisher(boost::bind(&SoapySDR::Device::getIQBalance, _device, dir, chan))
-            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setIQBalance, _device, dir, chan, _1));
+            .set_publisher([d=_device, dir, chan]() { return d->getIQBalance(dir, chan); })
+            .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setIQBalance(dir, chan, std::forward<decltype(v)>(v)); });
     }
 
     if (_device->hasIQBalanceMode(dir, chan))
     {
         _tree->create<bool>(rf_fe_path / "iq_balance" / "enable")
-            .set_publisher(boost::bind(&SoapySDR::Device::getIQBalanceMode, _device, dir, chan))
-            .add_desired_subscriber(boost::bind(&SoapySDR::Device::setIQBalanceMode, _device, dir, chan, _1));
+            .set_publisher([d=_device, dir, chan]() { return d->getIQBalanceMode(dir, chan); })
+            .add_desired_subscriber([d=_device, dir, chan](auto&& v) { return d->setIQBalanceMode(dir, chan, std::forward<decltype(v)>(v)); });
     }
 }
 
@@ -681,7 +676,7 @@ public:
         int ret = 0;
         if (activate) ret = _device->activateStream(_stream, flags, timeNs, numElems);
         else ret = _device->deactivateStream(_stream, flags, timeNs);
-        if (ret != 0) throw std::runtime_error(str(boost::format("UHDSoapyRxStream::issue_stream_cmd() = %d") % ret));
+        if (ret != 0) throw std::runtime_error("UHDSoapyRxStream::issue_stream_cmd() = " + std::to_string(ret));
     }
 
     #if UHD_VERSION >= 4080000
@@ -770,7 +765,7 @@ public:
             for (size_t i = 0; i < _nchan; i++) _offsetBuffs[i] = ((char *)buffs[i]) + total*_elemSize;
             int ret = _device->writeStream(_stream, &(_offsetBuffs[0]), numElems, flags, timeNs, long(timeout*1e6));
             if (ret == SOAPY_SDR_TIMEOUT) break;
-            if (ret < 0) throw std::runtime_error(str(boost::format("UHDSoapyTxStream::send() = %d") % ret));
+            if (ret < 0) throw std::runtime_error("UHDSoapyTxStream::send() = " + std::to_string(ret));
             total += ret;
         }
 


### PR DESCRIPTION
## Replace Boost with C++ standard library

### Changed

- `boost::lexical_cast<double>(s)` → `std::stod(s)` (3 sites)
- `boost::lexical_cast<std::string>(n)` → `std::to_string(n)` (2 sites)
- `boost::format("...") % a % b` → string concatenation with `+` (8 sites)
- `boost::bind(&fn, target, args...)` → C++14 lambdas with explicit captures (51 sites)
- `boost::mutex` / `scoped_lock` → `std::mutex` / `std::lock_guard<std::mutex>`
- `boost::uint32_t` → `std::uint32_t`
- Drop unused `<boost/foreach.hpp>` and `<boost/algorithm/string.hpp>`
- Drop `find_package(Boost)`, Boost link flags, `BOOST_ALL_DYN_LINK`
- Add `<cstdint>`, `<mutex>`

### Why

The Boost utilities replaced here all have C++14 equivalents.

UHD's CMake config still pulls `Boost_INCLUDE_DIRS` transitively via `find_dependency(Boost)` in `UHDConfig.cmake`, so UHD public headers that template-instantiate Boost types (e.g. `uhd::dict` in `dict.ipp`) keep compiling.
